### PR TITLE
Removed System.Web dependency

### DIFF
--- a/WatsonWebserver/HttpRequest.cs
+++ b/WatsonWebserver/HttpRequest.cs
@@ -8,7 +8,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WatsonWebserver
 {
@@ -276,7 +275,7 @@ namespace WatsonWebserver
                                 inKey = 1;
                                 inVal = 0;
 
-                                if (!String.IsNullOrEmpty(tempVal)) tempVal = HttpUtility.UrlDecode(tempVal);
+                                if (!String.IsNullOrEmpty(tempVal)) tempVal = System.Uri.EscapeUriString(tempVal);
                                 QuerystringEntries = WatsonCommon.AddToDict(tempKey, tempVal, QuerystringEntries);
                                 
                                 tempKey = "";
@@ -289,7 +288,7 @@ namespace WatsonWebserver
 
                     if (inVal == 1)
                     {
-                        if (!String.IsNullOrEmpty(tempVal)) tempVal = HttpUtility.UrlDecode(tempVal);
+                        if (!String.IsNullOrEmpty(tempVal)) tempVal = System.Uri.EscapeUriString(tempVal);
                         QuerystringEntries = WatsonCommon.AddToDict(tempKey, tempVal, QuerystringEntries);
                     }
                 }

--- a/WatsonWebserver/HttpResponse.cs
+++ b/WatsonWebserver/HttpResponse.cs
@@ -8,7 +8,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WatsonWebserver
 {

--- a/WatsonWebserver/WatsonCommon.cs
+++ b/WatsonWebserver/WatsonCommon.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
-using System.Web.Script.Serialization;
 using Newtonsoft.Json;
 
 namespace WatsonWebserver
@@ -38,19 +36,7 @@ namespace WatsonWebserver
 
         #region Public-Methods
 
-        /// <summary>
-        /// Serialize object to JSON using the built-in JSON serializer (JavaScriptSerializer).
-        /// </summary>
-        /// <param name="obj">The object to serialize.</param>
-        /// <returns>JSON string.</returns>
-        public static string SerializeJsonBuiltIn(object obj)
-        {
-            if (obj == null) return null;
-
-            JavaScriptSerializer ser = new JavaScriptSerializer();
-            ser.MaxJsonLength = Int32.MaxValue;
-            return ser.Serialize(obj);
-        }
+        
 
         /// <summary>
         /// Serialize object to JSON using Newtonsoft JSON.NET.
@@ -72,43 +58,7 @@ namespace WatsonWebserver
             return json;
         }
 
-        /// <summary>
-        /// Deserialize JSON string to an object using the built-in serializer (JavaScriptSerializer).
-        /// </summary>
-        /// <typeparam name="T">The type of object.</typeparam>
-        /// <param name="json">JSON string.</param>
-        /// <returns>An object of the specified type.</returns>
-        public static T DeserializeJsonBuiltIn<T>(string json)
-        {
-            if (String.IsNullOrEmpty(json)) throw new ArgumentNullException(nameof(json));
 
-            try
-            {
-                JavaScriptSerializer ser = new JavaScriptSerializer();
-                ser.MaxJsonLength = Int32.MaxValue;
-                return ser.Deserialize<T>(json);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("");
-                Console.WriteLine("Exception while deserializing:");
-                Console.WriteLine(json);
-                Console.WriteLine("");
-                throw e;
-            }
-        }
-
-        /// <summary>
-        /// Deserialize JSON string to an object using the built-in serializer (JavaScriptSerializer).
-        /// </summary>
-        /// <typeparam name="T">The type of object.</typeparam>
-        /// <param name="data">Byte array containing the JSON string.</param>
-        /// <returns>An object of the specified type.</returns>
-        public static T DeserializeJsonBuiltIn<T>(byte[] data)
-        {
-            if (data == null || data.Length < 1) throw new ArgumentNullException(nameof(data));
-            return DeserializeJsonBuiltIn<T>(Encoding.UTF8.GetString(data));
-        }
 
         /// <summary>
         /// Deserialize JSON string to an object using Newtonsoft JSON.NET.


### PR DESCRIPTION
Removes System.Web dependency, allowing WatsonWebserver to be compiled for Xamarin. Refer to the related [issue](https://github.com/jchristn/WatsonWebserver/issues/4).

- In HttpRequest and HttpResponse, replaces HttpUtility.UrlDecode for System.Uri.EscapeUriString
- Removes built in functions for deserialization