### PR TITLE
Added routes with attributes

### DIFF
--- a/Test.Routes/Program.cs
+++ b/Test.Routes/Program.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using WatsonWebserver;
+using WatsonWebserver.Routes;
+
+namespace Test.Routes
+{
+    class Program
+    {
+        static async Task Main()
+        {
+            // Create server and load all routes with the Route attribute in current assembly
+            using var server = new Server("127.0.0.1", 8080, false, DefaultRoute).LoadRoutes();
+            await Task.Delay(-1);
+            
+            // Load all methods with Route attribute from custom assembly
+            // server.LoadRoutes(Assembly.GetExecutingAssembly());
+        }
+
+        static async Task DefaultRoute(HttpContext context)
+        {
+            await context.Response.Send("Welcome to the default route!");
+        }
+        
+        [Route("hello")]
+        public async Task HelloRoute(HttpContext context)
+        {
+            await context.Response.Send("Welcome to the hello route!");
+        }
+        
+        [Route("post", HttpMethod.POST)]
+        public async Task PostRoute(HttpContext context)
+        {
+            await context.Response.Send("Welcome to the post route!");
+        }
+    }
+}

--- a/Test.Routes/Test.Routes.csproj
+++ b/Test.Routes/Test.Routes.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\WatsonWebserver\WatsonWebserver.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/WatsonWebserver.sln
+++ b/WatsonWebserver.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.DataReader", "Test.Dat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Docker", "Test.Docker\Test.Docker.csproj", "{DB3A183E-BF8A-4155-8376-899A0050AF1A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Routes", "Test.Routes\Test.Routes.csproj", "{1A980EE5-542D-4002-B859-4FF18A3C265A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,10 @@ Global
 		{DB3A183E-BF8A-4155-8376-899A0050AF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB3A183E-BF8A-4155-8376-899A0050AF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB3A183E-BF8A-4155-8376-899A0050AF1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A980EE5-542D-4002-B859-4FF18A3C265A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A980EE5-542D-4002-B859-4FF18A3C265A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A980EE5-542D-4002-B859-4FF18A3C265A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A980EE5-542D-4002-B859-4FF18A3C265A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WatsonWebserver/Routes/ReflectionCore.cs
+++ b/WatsonWebserver/Routes/ReflectionCore.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace WatsonWebserver.Routes
+{
+    public static class ReflectionCore
+    {
+        /// <summary>
+        /// Load routes from assembly
+        /// </summary>
+        /// <param name="server"></param>
+        /// <param name="assembly"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static T LoadRoutes<T>(this T server, Assembly assembly = null) where T : Server
+        {
+            var routes = (assembly ?? Assembly.GetCallingAssembly())
+                .GetTypes() // Get all classes from assembly
+                .SelectMany(x => x.GetMethods()) // Get all methods from assembly
+                .Where(IsValidRoute); // Only select methods that are valid routes
+
+            foreach (var route in routes)
+            {
+                var attribute = route.GetCustomAttributes().OfType<Route>().First();
+                server.StaticRoutes.Add(attribute.HttpMethod, attribute.RouteName, route.ToRouteMethod());
+            }
+
+            return server;
+        }
+
+        /// <summary>
+        /// Determines whether method is a valid route-method
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns>true when method is valid</returns>
+        private static bool IsValidRoute(MethodInfo method)
+            => method.GetCustomAttributes().OfType<Route>().Any() // Must have the Route attribute
+               && method.ReturnType == typeof(Task)
+               && method.GetParameters().Length == 1
+               && method.GetParameters().First().ParameterType == typeof(HttpContext); 
+
+        /// <summary>
+        /// Create delegate method from methodInfo
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns>static route method</returns>
+        private static Func<HttpContext, Task> ToRouteMethod(this MethodInfo method)
+        {
+            if (method.IsStatic)
+                return (Func<HttpContext, Task>) Delegate.CreateDelegate(typeof(Func<HttpContext, Task>), method);
+            else
+            {
+                object classInstance =
+                    Activator.CreateInstance(method.DeclaringType ?? throw new Exception("Declaring class is null"));
+                return (Func<HttpContext, Task>) Delegate.CreateDelegate(typeof(Func<HttpContext, Task>), classInstance,
+                    method);
+            }
+        }
+    }
+}

--- a/WatsonWebserver/Routes/Route.cs
+++ b/WatsonWebserver/Routes/Route.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace WatsonWebserver.Routes
+{
+    /// <summary>
+    /// Attribute that is used to mark methods as route-methods
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class Route : Attribute
+    {
+        public string RouteName { get; }
+        public HttpMethod HttpMethod { get; }
+        
+        /// <summary></summary>
+        /// <param name="routeName"></param>
+        /// <param name="httpMethod"></param>
+        public Route(string routeName, HttpMethod httpMethod = HttpMethod.GET)
+        {
+            RouteName = routeName;
+            HttpMethod = httpMethod;
+        }
+    }
+}


### PR DESCRIPTION
Added support for routes with attributes that are automatically loaded with reflection when calling `.LoadRoutes()`

Example:
```cs
using System.Threading.Tasks;
using WatsonWebserver;
using WatsonWebserver.Routes;

namespace Test.Routes
{
    class Program
    {
        static async Task Main()
        {
            // Create server and load all routes with the Route attribute in current assembly
            using var server = new Server("127.0.0.1", 8080, false, DefaultRoute).LoadRoutes();
            await Task.Delay(-1);

            // Load all methods with Route attribute from custom assembly
            // server.LoadRoutes(Assembly.GetExecutingAssembly());
        }

        static async Task DefaultRoute(HttpContext context)
        {
            await context.Response.Send("Welcome to the default route!");
        }

        [Route("hello")]
        public async Task HelloRoute(HttpContext context)
        {
            await context.Response.Send("Welcome to the hello route!");
        }

        [Route("post", HttpMethod.POST)]
        public async Task PostRoute(HttpContext context)
        {
            await context.Response.Send("Welcome to the post route!");
        }
    }
} 
```