### PR TITLE
Fixed Sending Chunked Data Example Code in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,16 +228,19 @@ static async Task DownloadChunkedFile(HttpContext ctx)
     ctx.Response.StatusCode = 200;
     ctx.Response.ChunkedTransfer = true;
 
-    byte[] buffer = new byte[65536];
-    int bytesRead = await fs.ReadAsync(buffer, 0, buffer.Length);
-    if (bytesRead > 0)
-    {
-      // you'll want to check bytesRead vs buffer.Length, of course!
-      await ctx.Response.SendChunk(buffer);
-    }
-    else
-    {
-      await ctx.Response.SendFinalChunk(buffer);
+    byte[] buffer = new byte[4096];
+    while(true){
+        int bytesRead = await fs.ReadAsync(buffer, 0, buffer.Length);
+        if (bytesRead > 0)
+        {
+          // you'll want to check bytesRead vs buffer.Length, of course!
+          await ctx.Response.SendChunk(buffer);
+        }
+        else
+        {
+          await ctx.Response.SendFinalChunk(buffer);
+          break;
+        }
     }
   }
 


### PR DESCRIPTION
Hello,

I noticed that the example  [code for sending Chunked Data](https://github.com/jchristn/WatsonWebserver/blob/master/README.md#sending-chunked-data) is not working correctly.

Bigger files get received corrupt.

I decreased the buffer size to 4096 because the old buffer size 65536 was way too big and could cause errors.
After wrapping the sending part with a while-loop it started working for bigger files too.

Best Regards,
Binozo