### PR TITLE
to download over 2gb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,11 @@ static async Task DownloadChunkedFile(HttpContext ctx)
       int bytesRead = await fs.ReadAsync(buffer, 0, buffer.Length);
       if (bytesRead > 0)
       {
-        // you'll want to check bytesRead vs buffer.Length, of course!
-        await ctx.Response.SendChunk(buffer);
+        await ctx.Response.SendChunk(buffer, bytesRead);
       }
       else
       {
-        await ctx.Response.SendFinalChunk(buffer);
+        await ctx.Response.SendFinalChunk(null, 0);
         break;
       }
     }

--- a/Test.ChunkServer/Program.cs
+++ b/Test.ChunkServer/Program.cs
@@ -102,6 +102,7 @@ namespace Test
                                     {
                                         Console.WriteLine("- Sending final chunk of size " + bytesRead);
 
+                                        /*
                                         if (bytesRead == buffer.Length)
                                         {
                                             await ctx.Response.SendFinalChunk(buffer);
@@ -112,6 +113,9 @@ namespace Test
                                             Buffer.BlockCopy(buffer, 0, temp, 0, bytesRead);
                                             await ctx.Response.SendFinalChunk(temp);
                                         }
+                                        */
+
+                                        await ctx.Response.SendFinalChunk(buffer, bytesRead);
                                     }
 
                                     bytesSent += bytesRead;
@@ -168,6 +172,7 @@ namespace Test
                                     {
                                         Console.WriteLine("- Sending final chunk of size " + bytesRead);
 
+                                        /*
                                         if (bytesRead == buffer.Length)
                                         {
                                             await ctx.Response.SendFinalChunk(buffer);
@@ -178,6 +183,9 @@ namespace Test
                                             Buffer.BlockCopy(buffer, 0, temp, 0, bytesRead);
                                             await ctx.Response.SendFinalChunk(temp);
                                         }
+                                        */
+
+                                        await ctx.Response.SendFinalChunk(buffer, bytesRead);
                                     }
 
                                     bytesSent += bytesRead;

--- a/Test.ChunkServer/Program.cs
+++ b/Test.ChunkServer/Program.cs
@@ -89,13 +89,13 @@ namespace Test
 
                                         if (bytesRead == buffer.Length)
                                         {
-                                            await ctx.Response.SendChunk(buffer);
+                                            await ctx.Response.SendChunk(buffer, bytesRead);
                                         }
                                         else
                                         {
                                             byte[] temp = new byte[bytesRead];
                                             Buffer.BlockCopy(buffer, 0, temp, 0, bytesRead);
-                                            await ctx.Response.SendChunk(temp);
+                                            await ctx.Response.SendChunk(temp, bytesRead);
                                         }
                                     }
                                     else
@@ -155,13 +155,13 @@ namespace Test
 
                                         if (bytesRead == buffer.Length)
                                         {
-                                            await ctx.Response.SendChunk(buffer);
+                                            await ctx.Response.SendChunk(buffer, bytesRead);
                                         }
                                         else
                                         {
                                             byte[] temp = new byte[bytesRead];
                                             Buffer.BlockCopy(buffer, 0, temp, 0, bytesRead);
-                                            await ctx.Response.SendChunk(temp);
+                                            await ctx.Response.SendChunk(temp, bytesRead);
                                         }
                                     }
                                     else

--- a/WatsonWebserver/HttpResponse.cs
+++ b/WatsonWebserver/HttpResponse.cs
@@ -392,9 +392,10 @@ namespace WatsonWebserver
         /// Send headers (if not already sent) and a chunk of data using chunked transfer-encoding, and keep the connection in-tact.
         /// </summary>
         /// <param name="chunk">Chunk of data.</param>
+        /// <param name="nDataSize">not a buffer size, but a real data size(return value of filestream.ReadAsync(buffer, 0, buffer.Length) )</param>
         /// <param name="token">Cancellation token useful for canceling the request.</param>
         /// <returns>True if successful.</returns>
-        public async Task<bool> SendChunk(byte[] chunk, CancellationToken token = default)
+        public async Task<bool> SendChunk(byte[] chunk, int nDataSize, CancellationToken token = default)
         {
             if (!ChunkedTransfer) throw new IOException("Response is not configured to use chunked transfer-encoding.  Set ChunkedTransfer to true first, otherwise use Send().");
             if (!_HeadersSent) SendHeaders();
@@ -407,9 +408,9 @@ namespace WatsonWebserver
             try
             {
                 if (chunk == null || chunk.Length < 1) chunk = new byte[0];
-                if (_Data == null) _Data = new MemoryStream();
-                await _Data.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
-                await _OutputStream.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
+                //if (_Data == null) _Data = new MemoryStream();
+                //await _Data.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
+                await _OutputStream.WriteAsync(chunk, 0, nDataSize, token).ConfigureAwait(false);
                 await _OutputStream.FlushAsync(token).ConfigureAwait(false);
             }
             catch (Exception)

--- a/WatsonWebserver/HttpResponse.cs
+++ b/WatsonWebserver/HttpResponse.cs
@@ -425,9 +425,10 @@ namespace WatsonWebserver
         /// Send headers (if not already sent) and the final chunk of data using chunked transfer-encoding and terminate the connection.
         /// </summary>
         /// <param name="chunk">Chunk of data.</param>
+        /// <param name="nDataSize">not a buffer size, but a real data size(return value of filestream.ReadAsync(buffer, 0, buffer.Length) )</param>
         /// <param name="token">Cancellation token useful for canceling the request.</param>
         /// <returns>True if successful.</returns>
-        public async Task<bool> SendFinalChunk(byte[] chunk, CancellationToken token = default)
+        public async Task<bool> SendFinalChunk(byte[] chunk, int nDataSize, CancellationToken token = default)
         {
             if (!ChunkedTransfer) throw new IOException("Response is not configured to use chunked transfer-encoding.  Set ChunkedTransfer to true first, otherwise use Send().");
             if (!_HeadersSent) SendHeaders();
@@ -441,9 +442,9 @@ namespace WatsonWebserver
             { 
                 if (chunk != null && chunk.Length > 0)
                 {
-                    if (_Data == null) _Data = new MemoryStream();
-                    await _Data.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
-                    await _OutputStream.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
+                    //if (_Data == null) _Data = new MemoryStream();
+                    //await _Data.WriteAsync(chunk, 0, chunk.Length, token).ConfigureAwait(false);
+                    await _OutputStream.WriteAsync(chunk, 0, nDataSize, token).ConfigureAwait(false);
                 }
 
                 byte[] endChunk = new byte[0];
@@ -452,7 +453,7 @@ namespace WatsonWebserver
                 await _OutputStream.FlushAsync(token).ConfigureAwait(false);
                 _OutputStream.Close();
 
-                _Data.Seek(0, SeekOrigin.Begin);
+                //_Data.Seek(0, SeekOrigin.Begin);
 
                 if (_Response != null) _Response.Close();
 

--- a/WatsonWebserver/WatsonWebserver.xml
+++ b/WatsonWebserver/WatsonWebserver.xml
@@ -875,11 +875,12 @@
             <param name="token">Cancellation token useful for canceling the request.</param>
             <returns>True if successful.</returns>
         </member>
-        <member name="M:WatsonWebserver.HttpResponse.SendFinalChunk(System.Byte[],System.Threading.CancellationToken)">
+        <member name="M:WatsonWebserver.HttpResponse.SendFinalChunk(System.Byte[],System.Int32,System.Threading.CancellationToken)">
             <summary>
             Send headers (if not already sent) and the final chunk of data using chunked transfer-encoding and terminate the connection.
             </summary>
             <param name="chunk">Chunk of data.</param>
+            <param name="nDataSize">not a buffer size, but a real data size(return value of filestream.ReadAsync(buffer, 0, buffer.Length) )</param>
             <param name="token">Cancellation token useful for canceling the request.</param>
             <returns>True if successful.</returns>
         </member>

--- a/WatsonWebserver/WatsonWebserver.xml
+++ b/WatsonWebserver/WatsonWebserver.xml
@@ -866,11 +866,12 @@
             <param name="token">Cancellation token useful for canceling the request.</param>
             <returns>True if successful.</returns>
         </member>
-        <member name="M:WatsonWebserver.HttpResponse.SendChunk(System.Byte[],System.Threading.CancellationToken)">
+        <member name="M:WatsonWebserver.HttpResponse.SendChunk(System.Byte[],System.Int32,System.Threading.CancellationToken)">
             <summary>
             Send headers (if not already sent) and a chunk of data using chunked transfer-encoding, and keep the connection in-tact.
             </summary>
             <param name="chunk">Chunk of data.</param>
+            <param name="nDataSize">not a buffer size, but a real data size(return value of filestream.ReadAsync(buffer, 0, buffer.Length) )</param>
             <param name="token">Cancellation token useful for canceling the request.</param>
             <returns>True if successful.</returns>
         </member>


### PR DESCRIPTION
I modified sendChunk() and sendFinalChunk() functions to send over 2gb files. 

I added nDataSize parameter to send real data. nDataSize is the return value of ReadAsync() function. It's useful when it processes the last block.

MemoryStream can't deal over 2gb files. So I removed "MemoryStream _Data" variable. I could not find the purpose of _Data variable.

And I modified README.md file 