### PR TITLE
feat: Introduce UseMachineHostname for robust Host header handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,47 @@ static async Task TestRoute(HttpContextBase ctx) =>
     await ctx.Response.Send("Hello from the test route!"); 
 ```
 
+## Hostname Handling for HTTP Responses
+
+To correctly handle the `Host` HTTP header, a new boolean property, `UseMachineHostname`, has been introduced in `WebserverSettings`. This is especially important when using wildcard bindings.
+
+-   **Wildcard Binding Behavior**: When `Hostname` is set to `*` or `+`, the server will **mandatorily** use the machine's actual hostname for the `Host` header in HTTP responses. This prevents `UriFormatException` on modern .NET runtimes. In this scenario, `UseMachineHostname` is forced to `true`.
+
+-   **Default Behavior**: For any other hostname (e.g., `localhost` or an IP address), this feature is **disabled by default**. The `Host` header will use the value specified in the `Hostname` setting.
+
+-   **Manual Activation**: You can force the use of the machine's hostname for any binding by setting `UseMachineHostname = true` in the settings.
+
+### Usage
+
+**Example 1: Using a Wildcard (Mandatory Machine Hostname)**
+
+```csharp
+// The server detects the wildcard and mandatorily uses the machine's hostname for the Host header.
+var server = new Server("*", 9000, false, DefaultRoute);
+server.Start();
+```
+
+**Example 2: Manually Enabling for a Specific Hostname**
+
+```csharp
+// By default, the Host header would be "localhost:9000".
+// By setting UseMachineHostname = true, we force it to use the machine's actual hostname.
+var settings = new WebserverSettings("localhost", 9000);
+settings.UseMachineHostname = true; 
+var server = new Server(settings, DefaultRoute);
+server.Start();
+```
+
+### Hostname Examples
+
+When `UseMachineHostname` is active, the retrieved hostname will vary depending on the operating system and network configuration. Here are some typical examples (after sanitization):
+
+-   **Windows**: `desktop-a1b2c3d`
+-   **macOS**: `marcos-macbook-pro.local`
+-   **Linux**: `ubuntu-server`
+-   **Android**: `pixel-7-pro`
+-   **iOS**: `marcos-iphone.local`
+
 ## Accessing from Outside Localhost
 
 ### Watson

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -1587,6 +1587,22 @@
             Stop accepting new connections.
             </summary>
         </member>
+        <member name="M:WatsonWebserver.Core.WebserverBase.GetBestLocalHostName">
+            <summary>
+            Robustly retrieves and sanitizes a valid hostname for the local machine
+            by trying several strategies in order of preference.
+            This method is safe to use on all platforms, including iOS and Android.
+            </summary>
+            <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        </member>
+        <member name="M:WatsonWebserver.Core.WebserverBase.SanitizeHostName(System.String)">
+            <summary>
+            Converts a string into a valid RFC 1123 hostname.
+            It removes invalid characters, converts to lowercase, and handles hyphens.
+            </summary>
+            <param name="potentialName">The name to sanitize.</param>
+            <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        </member>
         <member name="T:WatsonWebserver.Core.WebserverConstants">
             <summary>
             Webserver constants.
@@ -1966,6 +1982,11 @@
             <summary>
             Debug logging settings.
             Be sure to set Events.Logger in order to receive debug messages.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.WebserverSettings.UseMachineHostname">
+            <summary>
+            When true, the machine's hostname will be used instead of the value specified in Hostname.
             </summary>
         </member>
         <member name="M:WatsonWebserver.Core.WebserverSettings.#ctor">

--- a/src/WatsonWebserver.Core/WebserverSettings.cs
+++ b/src/WatsonWebserver.Core/WebserverSettings.cs
@@ -141,6 +141,22 @@
             }
         }
 
+        /// <summary>
+        /// When true, the machine's hostname will be used instead of the value specified in Hostname.
+        /// </summary>
+        public bool UseMachineHostname
+        {
+            get
+            {
+                if (Hostname == "*" || Hostname == "+") return true;
+                return _UseMachineHostname;
+            }
+            set
+            {
+                _UseMachineHostname = (Hostname == "*" || Hostname == "+") || value;
+            }
+        }
+
         #endregion
 
         #region Private-Members
@@ -152,6 +168,7 @@
         private AccessControlManager _AccessControl = new AccessControlManager(AccessControlMode.DefaultPermit);
         private DebugSettings _Debug = new DebugSettings();
         private HeaderSettings _Headers = new HeaderSettings();
+        private bool _UseMachineHostname = false;
 
         #endregion
 
@@ -161,7 +178,7 @@
         /// Webserver settings.
         /// </summary>
         public WebserverSettings()
-        { 
+        {
 
         }
 
@@ -190,7 +207,7 @@
         #endregion
 
         #region Private-Methods
-        
+
         #endregion
 
         #region Public-Classes
@@ -357,7 +374,7 @@
             /// </summary>
             public SslSettings()
             {
-            } 
+            }
         }
 
         /// <summary>
@@ -369,7 +386,7 @@
             /// Automatically set content length if not already set.
             /// </summary>
             public bool IncludeContentLength { get; set; } = true;
-            
+
             /// <summary>
             /// Headers to add to each request.
             /// </summary>
@@ -424,7 +441,7 @@
             /// Enable or disable debug logging of routing.
             /// </summary>
             public bool Routing { get; set; } = false;
-              
+
             /// <summary>
             /// Enable or disable debug logging of requests.
             /// </summary>

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -1,57 +1,60 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.12</Version>
-		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
-		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
-		<Authors>Joel Christner</Authors>
-		<Company>Joel Christner</Company>
-		<Copyright>(c)2025 Joel Christner</Copyright>
-		<PackageProjectUrl>https://github.com/dotnet/WatsonWebserver</PackageProjectUrl>
-		<PackageLicenseUrl></PackageLicenseUrl>
-		<RepositoryUrl>https://github.com/dotnet/WatsonWebserver</RepositoryUrl>
-		<RepositoryType>Github</RepositoryType>
-		<PackageTags>web server rest restful http https api async ssl</PackageTags>
-		<PackageId>Watson.Lite</PackageId>
-		<Product>Watson.Lite</Product>
-		<PackageIconUrl></PackageIconUrl>
-		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-		<PackageIcon>watson.png</PackageIcon>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<IncludeSymbols>True</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Title>Watson Webserver Lite</Title>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<DocumentationFile>WatsonWebserver.Lite.xml</DocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
+    <Version>6.3.12</Version>
+    <Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
+    <PackageReleaseNotes>Dependency update</PackageReleaseNotes>
+    <Authors>Joel Christner</Authors>
+    <Company>Joel Christner</Company>
+    <Copyright>(c)2025 Joel Christner</Copyright>
+    <PackageProjectUrl>https://github.com/dotnet/WatsonWebserver</PackageProjectUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/dotnet/WatsonWebserver</RepositoryUrl>
+    <RepositoryType>Github</RepositoryType>
+    <PackageTags>web server rest restful http https api async ssl</PackageTags>
+    <PackageId>Watson.Lite</PackageId>
+    <Product>Watson.Lite</Product>
+    <PackageIconUrl></PackageIconUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageIcon>watson.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Title>Watson Webserver Lite</Title>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DocumentationFile>WatsonWebserver.Lite.xml</DocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.12" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CavemanTcp" Version="2.0.9" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-		<None Include="assets\watson.png">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="LICENSE.md">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="assets\watson.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="LICENSE.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Update="WatsonWebserver.Lite.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WatsonWebserver.Core\WatsonWebserver.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="WatsonWebserver.Lite.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/WatsonWebserver.Lite/Webserver.cs
+++ b/src/WatsonWebserver.Lite/Webserver.cs
@@ -66,10 +66,13 @@
         /// <param name="defaultRoute">Default route.</param>
         public WebserverLite(WebserverSettings settings, Func<HttpContextBase, Task> defaultRoute) : base(settings, defaultRoute)
         {
-            if (settings == null) settings = new WebserverSettings(); 
+            if (settings == null) settings = new WebserverSettings();
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+
             Routes = new WebserverRoutes(Settings, defaultRoute);
 
             _Header = "[Webserver " + Settings.Prefix + "] ";

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -1,56 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.12</Version>
-		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
-		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
-		<Authors>Joel Christner</Authors>
-		<Company>Joel Christner</Company>
-		<Copyright>(c)2025 Joel Christner</Copyright>
-		<PackageProjectUrl>https://github.com/dotnet/WatsonWebserver</PackageProjectUrl>
-		<PackageLicenseUrl></PackageLicenseUrl>
-		<RepositoryUrl>https://github.com/dotnet/WatsonWebserver</RepositoryUrl>
-		<RepositoryType>Github</RepositoryType>
-		<PackageTags>web server rest restful http https api async ssl</PackageTags>
-		<PackageId>Watson</PackageId>
-		<Product>Watson</Product>
-		<PackageIconUrl></PackageIconUrl>
-		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-		<PackageIcon>watson.png</PackageIcon>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<IncludeSymbols>True</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Title>Watson Webserver</Title>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<DocumentationFile>WatsonWebserver.xml</DocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
+    <Version>6.3.12</Version>
+    <Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
+    <PackageReleaseNotes>Dependency update</PackageReleaseNotes>
+    <Authors>Joel Christner</Authors>
+    <Company>Joel Christner</Company>
+    <Copyright>(c)2025 Joel Christner</Copyright>
+    <PackageProjectUrl>https://github.com/dotnet/WatsonWebserver</PackageProjectUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/dotnet/WatsonWebserver</RepositoryUrl>
+    <RepositoryType>Github</RepositoryType>
+    <PackageTags>web server rest restful http https api async ssl</PackageTags>
+    <PackageId>Watson</PackageId>
+    <Product>Watson</Product>
+    <PackageIconUrl></PackageIconUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageIcon>watson.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Title>Watson Webserver</Title>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DocumentationFile>WatsonWebserver.xml</DocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\..\README.md">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
-		<None Include="assets\watson.png">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="LICENSE.md">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="assets\watson.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="LICENSE.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.12" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WatsonWebserver.Core\WatsonWebserver.Core.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <None Update="WatsonWebserver.xml">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="WatsonWebserver.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -69,7 +69,10 @@
             if (settings == null) settings = new WebserverSettings();
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+
             Routes.Default = defaultRoute;
 
             _Header = "[Webserver " + Settings.Prefix + "] ";
@@ -261,7 +264,7 @@
                                     }
 
                                     await Routes.Preflight(ctx).ConfigureAwait(false);
-                                    if (!ctx.Response.ResponseSent) 
+                                    if (!ctx.Response.ResponseSent)
                                         throw new InvalidOperationException("Preflight route for " + ctx.Request.Method.ToString() + " " + ctx.Request.Url.RawWithoutQuery + " did not send a response to the HTTP request.");
                                     return;
                                 }
@@ -324,7 +327,7 @@
                                             else throw;
                                         }
 
-                                        if (!ctx.Response.ResponseSent) 
+                                        if (!ctx.Response.ResponseSent)
                                             throw new InvalidOperationException("Pre-authentication static route for " + ctx.Request.Method.ToString() + " " + ctx.Request.Url.RawWithoutQuery + " did not send a response to the HTTP request.");
                                         return;
                                     }


### PR DESCRIPTION
feat: Introduce UseMachineHostname for robust Host header handling

This PR introduces a new feature (`UseMachineHostname` in `WebserverSettings`) to provide robust control over the `Host` HTTP header and resolve a critical compatibility issue with modern .NET runtimes (.NET 9 and later).

### The Problem
Starting with .NET 9, the `System.Uri` class enforces stricter validation for hostnames according to RFC standards. This causes a `UriFormatException` when initializing the server with wildcard hostnames like `*` or `+`, as the library was incorrectly using these invalid characters to build the default `Host` HTTP header.

While existing users can work around this issue by using `0.0.0.0` to bind to all interfaces, this solution is not always intuitive and doesn't address the underlying issue of how wildcards are handled.

### The Solution: A New Feature
This feature introduces the `UseMachineHostname` boolean property to `WebserverSettings`, which provides a more elegant and powerful solution:

1.  **Automatic Hostname Resolution for Wildcards**: When the server is configured with `Hostname = "*"` or `Hostname = "+"`, the `UseMachineHostname` property is **mandatorily enabled**. This forces the server to automatically retrieve the machine's actual hostname for use in the `Host` header, while the network listener continues to correctly bind to all network interfaces. This completely resolves the compatibility issue.

2.  **Manual Control**: Developers can now manually set `UseMachineHostname = true` for **any** hostname (e.g., `localhost` or a specific IP). This gives them the flexibility to have the server's `Host` header always reflect the machine's network name, regardless of the binding configuration. By default, this behavior is disabled unless a wildcard is used.

3.  **Robust and Safe Hostname Retrieval**: The machine hostname is retrieved using a robust fallback mechanism (`Dns.GetHostName()` -> `Environment.MachineName` -> `localhost`). Furthermore, the retrieved name is sanitized to be **RFC 1123 compliant**, ensuring it is always a valid hostname, even if the device name contains spaces or special characters (e.g., "My Dev Machine" becomes "my-dev-machine").

This enhancement not only fixes a breaking change but also adds valuable functionality, giving developers more precise control over how the server identifies itself in HTTP responses.

### Additional Improvements
Additionally, this PR updates the project references to `Watson.Core` within `Watson` and `Watson.Lite` to use `ProjectReference`. This ensures that the NuGet packaging system correctly resolves the dependency, as the `Watson.Core` project has its `Version` and `PackageId` properties properly configured. This leads to a more reliable build, testing and packaging process.

