### PR TITLE
Fix active request disconnect cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-`v7.0.14`
+`v7.0.15`
 
 ## Unreleased
 
@@ -11,6 +11,11 @@
 - Added exhaustive shared websocket-client coverage in `Test.Shared`, wired into both `Test.XUnit` and `Test.Automated`, and extended server/client interop validation through that suite
 - Updated `Test.WebsocketClient` to exercise `WatsonWebSocketClient` instead of raw `ClientWebSocket`
 - Expanded `README.md` and `MIGRATING_FROM_WATSONWEBSOCKET.md` so WatsonWebsocket client migrations now have first-class documentation alongside the server guidance
+
+## v7.0.15
+
+- Fixed active in-flight caller disconnect propagation so HTTP/1.1 socket disconnects, HTTP/2 `RST_STREAM` frames, and HTTP/3 response-side stream closures cancel the active request token and raise `RequestAborted` / `RequestorDisconnected` while route handlers are still running
+- Added shared protocol regression coverage for HTTP/1.1 caller disconnects and HTTP/2 `RST_STREAM` cancellation, wired into both `Test.Automated` and `Test.XUnit`
 
 ## v7.0.14
 

--- a/src/Test.Automated/SharedProtocolGapSuite.cs
+++ b/src/Test.Automated/SharedProtocolGapSuite.cs
@@ -25,6 +25,8 @@ namespace Test.Automated
             _Results.Clear();
 
             await ExecuteTestAsync("HTTP/2 :: Writer Serialization Correctness", ProtocolGapSharedTests.RunHttp2WriterSerializationCorrectnessAsync).ConfigureAwait(false);
+            await ExecuteTestAsync("HTTP/1.1 :: Caller Disconnect Cancels Active Request", ProtocolGapSharedTests.RunHttp1CallerDisconnectCancelsActiveRequestAsync).ConfigureAwait(false);
+            await ExecuteTestAsync("HTTP/2 :: RST_STREAM Cancels Active Request", ProtocolGapSharedTests.RunHttp2RstStreamCancelsActiveRequestAsync).ConfigureAwait(false);
             await ExecuteTestAsync("HTTP/3 :: Transport Backpressure Behavior", ProtocolGapSharedTests.RunHttp3TransportBackpressureAsync).ConfigureAwait(false);
             await ExecuteTestAsync("HTTP/3 :: Sibling Stream Survival After Abort", ProtocolGapSharedTests.RunHttp3SiblingStreamSurvivalAsync).ConfigureAwait(false);
             await ExecuteTestAsync("Cross-Protocol :: Auth, Session, And Event Parity", ProtocolGapSharedTests.RunCrossProtocolAuthSessionEventParityAsync).ConfigureAwait(false);

--- a/src/Test.Shared/ProtocolGapSharedTests.cs
+++ b/src/Test.Shared/ProtocolGapSharedTests.cs
@@ -270,6 +270,110 @@ namespace Test.Shared
             }).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that an HTTP/1.1 caller disconnect cancels the active request token before response write.
+        /// </summary>
+        /// <returns>Task.</returns>
+        public static async Task RunHttp1CallerDisconnectCancelsActiveRequestAsync()
+        {
+            await ExecuteWithRetryAsync(async () =>
+            {
+                TaskCompletionSource<bool> routeEntered = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> tokenCancelled = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> requestAborted = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> requestorDisconnected = CreateTaskCompletionSource<bool>();
+
+                using (LoopbackServerHost host = new LoopbackServerHost(false, false, false, server =>
+                {
+                    ConfigureDisconnectRoutes(server, routeEntered, tokenCancelled, requestAborted, requestorDisconnected);
+                }))
+                {
+                    await host.StartAsync().ConfigureAwait(false);
+
+                    using (TcpClient client = new TcpClient())
+                    {
+                        await client.ConnectAsync("127.0.0.1", host.Port).ConfigureAwait(false);
+                        NetworkStream stream = client.GetStream();
+                        byte[] requestBytes = Encoding.ASCII.GetBytes(
+                            "GET /test/disconnect-wait HTTP/1.1\r\n" +
+                            "Host: 127.0.0.1:" + host.Port.ToString() + "\r\n" +
+                            "Connection: keep-alive\r\n" +
+                            "\r\n");
+
+                        await stream.WriteAsync(requestBytes, 0, requestBytes.Length).ConfigureAwait(false);
+                        await stream.FlushAsync().ConfigureAwait(false);
+                        await WaitForTaskAsync(routeEntered.Task, "HTTP/1.1 route did not start.").ConfigureAwait(false);
+
+                        client.Client.Shutdown(SocketShutdown.Both);
+                    }
+
+                    await WaitForTaskAsync(tokenCancelled.Task, "HTTP/1.1 route token was not canceled after caller disconnect.").ConfigureAwait(false);
+                    await WaitForTaskAsync(requestAborted.Task, "HTTP/1.1 RequestAborted event did not fire.").ConfigureAwait(false);
+                    await WaitForTaskAsync(requestorDisconnected.Task, "HTTP/1.1 RequestorDisconnected event did not fire.").ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an HTTP/2 RST_STREAM cancels the active request token and emits disconnect events.
+        /// </summary>
+        /// <returns>Task.</returns>
+        public static async Task RunHttp2RstStreamCancelsActiveRequestAsync()
+        {
+            await ExecuteWithRetryAsync(async () =>
+            {
+                TaskCompletionSource<bool> routeEntered = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> tokenCancelled = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> requestAborted = CreateTaskCompletionSource<bool>();
+                TaskCompletionSource<bool> requestorDisconnected = CreateTaskCompletionSource<bool>();
+
+                using (LoopbackServerHost host = new LoopbackServerHost(false, true, false, server =>
+                {
+                    ConfigureDisconnectRoutes(server, routeEntered, tokenCancelled, requestAborted, requestorDisconnected);
+                }))
+                {
+                    await host.StartAsync().ConfigureAwait(false);
+
+                    using (TcpClient client = new TcpClient())
+                    {
+                        await client.ConnectAsync("127.0.0.1", host.Port).ConfigureAwait(false);
+
+                        using (NetworkStream stream = client.GetStream())
+                        {
+                            await PerformHttp2ClientHandshakeAsync(stream).ConfigureAwait(false);
+
+                            byte[] requestHeaderBytes = BuildHttp2RequestHeaderBlock("GET", "http", "127.0.0.1:" + host.Port.ToString(), "/test/disconnect-wait");
+                            Http2RawFrame requestFrame = new Http2RawFrame(
+                                new Http2FrameHeader
+                                {
+                                    Length = requestHeaderBytes.Length,
+                                    Type = Http2FrameType.Headers,
+                                    Flags = (byte)((byte)Http2FrameFlags.EndHeaders | (byte)Http2FrameFlags.EndStreamOrAck),
+                                    StreamIdentifier = 1
+                                },
+                                requestHeaderBytes);
+
+                            byte[] requestWireBytes = Http2FrameSerializer.SerializeFrame(requestFrame);
+                            await stream.WriteAsync(requestWireBytes, 0, requestWireBytes.Length).ConfigureAwait(false);
+                            await stream.FlushAsync().ConfigureAwait(false);
+                            await WaitForTaskAsync(routeEntered.Task, "HTTP/2 route did not start.").ConfigureAwait(false);
+
+                            Http2RstStreamFrame resetFrame = new Http2RstStreamFrame();
+                            resetFrame.StreamIdentifier = 1;
+                            resetFrame.ErrorCode = Http2ErrorCode.Cancel;
+                            byte[] resetWireBytes = Http2FrameSerializer.SerializeFrame(Http2FrameSerializer.CreateRstStreamFrame(resetFrame));
+                            await stream.WriteAsync(resetWireBytes, 0, resetWireBytes.Length).ConfigureAwait(false);
+                            await stream.FlushAsync().ConfigureAwait(false);
+                        }
+                    }
+
+                    await WaitForTaskAsync(tokenCancelled.Task, "HTTP/2 route token was not canceled after RST_STREAM.").ConfigureAwait(false);
+                    await WaitForTaskAsync(requestAborted.Task, "HTTP/2 RequestAborted event did not fire.").ConfigureAwait(false);
+                    await WaitForTaskAsync(requestorDisconnected.Task, "HTTP/2 RequestorDisconnected event did not fire.").ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+
         private static void ConfigureCommonRoutes(Webserver server)
         {
             if (server == null) throw new ArgumentNullException(nameof(server));
@@ -338,6 +442,57 @@ namespace Test.Shared
                 response.Path = req.Http.Request.Url.RawWithoutQuery;
                 return response;
             }, auth: true);
+        }
+
+        private static void ConfigureDisconnectRoutes(
+            Webserver server,
+            TaskCompletionSource<bool> routeEntered,
+            TaskCompletionSource<bool> tokenCancelled,
+            TaskCompletionSource<bool> requestAborted,
+            TaskCompletionSource<bool> requestorDisconnected)
+        {
+            if (server == null) throw new ArgumentNullException(nameof(server));
+            if (routeEntered == null) throw new ArgumentNullException(nameof(routeEntered));
+            if (tokenCancelled == null) throw new ArgumentNullException(nameof(tokenCancelled));
+            if (requestAborted == null) throw new ArgumentNullException(nameof(requestAborted));
+            if (requestorDisconnected == null) throw new ArgumentNullException(nameof(requestorDisconnected));
+
+            server.Events.RequestAborted += (sender, args) =>
+            {
+                if (IsDisconnectWaitEvent(args))
+                {
+                    requestAborted.TrySetResult(true);
+                }
+            };
+
+            server.Events.RequestorDisconnected += (sender, args) =>
+            {
+                if (IsDisconnectWaitEvent(args))
+                {
+                    requestorDisconnected.TrySetResult(true);
+                }
+            };
+
+            server.Routes.PreAuthentication.Static.Add(CoreHttpMethod.GET, "/test/disconnect-wait", async (ctx) =>
+            {
+                routeEntered.TrySetResult(true);
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(30), ctx.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    tokenCancelled.TrySetResult(true);
+                }
+            });
+        }
+
+        private static bool IsDisconnectWaitEvent(RequestEventArgs args)
+        {
+            return args != null
+                && !String.IsNullOrEmpty(args.Url)
+                && args.Url.IndexOf("/test/disconnect-wait", StringComparison.Ordinal) >= 0;
         }
 
         private static async Task AssertSecureRouteAsync(Uri baseAddress, Version version)
@@ -469,6 +624,26 @@ namespace Test.Shared
             }
 
             throw lastException ?? new InvalidOperationException("Retryable shared protocol test failed without an exception.");
+        }
+
+        private static async Task WaitForTaskAsync(Task task, string failureMessage)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+            if (String.IsNullOrEmpty(failureMessage)) throw new ArgumentNullException(nameof(failureMessage));
+
+            Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
+            Task completedTask = await Task.WhenAny(task, timeoutTask).ConfigureAwait(false);
+            if (completedTask != task)
+            {
+                throw new TimeoutException(failureMessage);
+            }
+
+            await task.ConfigureAwait(false);
+        }
+
+        private static TaskCompletionSource<T> CreateTaskCompletionSource<T>()
+        {
+            return new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         private static async Task<Http2RawFrame> PerformHttp2ClientHandshakeAsync(NetworkStream stream)

--- a/src/Test.XUnit/ProtocolGapSharedTests.cs
+++ b/src/Test.XUnit/ProtocolGapSharedTests.cs
@@ -24,6 +24,26 @@ namespace Test.XUnit
         }
 
         /// <summary>
+        /// Verify HTTP/1.1 caller disconnect cancels an active request.
+        /// </summary>
+        /// <returns>Task.</returns>
+        [Fact]
+        public async Task Http1CallerDisconnectCancelsActiveRequest()
+        {
+            await Test.Shared.ProtocolGapSharedTests.RunHttp1CallerDisconnectCancelsActiveRequestAsync();
+        }
+
+        /// <summary>
+        /// Verify HTTP/2 RST_STREAM cancels an active request.
+        /// </summary>
+        /// <returns>Task.</returns>
+        [Fact]
+        public async Task Http2RstStreamCancelsActiveRequest()
+        {
+            await Test.Shared.ProtocolGapSharedTests.RunHttp2RstStreamCancelsActiveRequestAsync();
+        }
+
+        /// <summary>
         /// Verify HTTP/3 transport backpressure behavior.
         /// </summary>
         /// <returns>Task.</returns>

--- a/src/WatsonWebserver/Http1/ClientStreamContext.cs
+++ b/src/WatsonWebserver/Http1/ClientStreamContext.cs
@@ -2,6 +2,7 @@ namespace WatsonWebserver.Http1
 {
     using System;
     using System.IO;
+    using System.Net.Sockets;
     using WatsonWebserver.Core;
 
     /// <summary>
@@ -13,6 +14,11 @@ namespace WatsonWebserver.Http1
         /// Negotiated application protocol.
         /// </summary>
         public HttpProtocol Protocol { get; set; } = HttpProtocol.Http1;
+
+        /// <summary>
+        /// Underlying client socket.
+        /// </summary>
+        public Socket Socket { get; set; } = null;
 
         /// <summary>
         /// Client stream.

--- a/src/WatsonWebserver/Http2/Http2ConnectionSession.cs
+++ b/src/WatsonWebserver/Http2/Http2ConnectionSession.cs
@@ -23,6 +23,7 @@ namespace WatsonWebserver.Http2
         /// <param name="events">Server events.</param>
         /// <param name="stream">Transport stream.</param>
         /// <param name="processContext">Shared request processor.</param>
+        /// <param name="markRequestTerminated">Request termination callback.</param>
         /// <param name="source">Source endpoint.</param>
         /// <param name="destination">Destination endpoint.</param>
         /// <param name="encrypted">True if the connection is encrypted.</param>
@@ -31,6 +32,7 @@ namespace WatsonWebserver.Http2
             WebserverEvents events,
             Stream stream,
             Func<HttpContextBase, CancellationToken, Task> processContext,
+            Action<HttpContextBase, bool> markRequestTerminated,
             IPEndPoint source,
             IPEndPoint destination,
             bool encrypted)
@@ -39,6 +41,7 @@ namespace WatsonWebserver.Http2
             if (events == null) throw new ArgumentNullException(nameof(events));
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (processContext == null) throw new ArgumentNullException(nameof(processContext));
+            if (markRequestTerminated == null) throw new ArgumentNullException(nameof(markRequestTerminated));
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (destination == null) throw new ArgumentNullException(nameof(destination));
 
@@ -46,6 +49,7 @@ namespace WatsonWebserver.Http2
             _Events = events;
             _Stream = stream;
             _ProcessContext = processContext;
+            _MarkRequestTerminated = markRequestTerminated;
             _Source = source;
             _Destination = destination;
             _Encrypted = encrypted;
@@ -102,10 +106,12 @@ namespace WatsonWebserver.Http2
             }
             catch (EndOfStreamException)
             {
+                CancelActiveRequests(true);
                 _State = Http2ConnectionState.Closed;
             }
             catch (IOException)
             {
+                CancelActiveRequests(true);
                 _State = Http2ConnectionState.Closed;
             }
             finally
@@ -143,6 +149,7 @@ namespace WatsonWebserver.Http2
         private readonly WebserverEvents _Events;
         private readonly Stream _Stream;
         private readonly Func<HttpContextBase, CancellationToken, Task> _ProcessContext;
+        private readonly Action<HttpContextBase, bool> _MarkRequestTerminated;
         private readonly IPEndPoint _Source;
         private readonly IPEndPoint _Destination;
         private readonly bool _Encrypted;
@@ -153,7 +160,7 @@ namespace WatsonWebserver.Http2
         private readonly Dictionary<int, Http2StreamStateMachine> _Streams = new Dictionary<int, Http2StreamStateMachine>();
         private readonly Dictionary<int, Http2PendingRequest> _PendingRequests = new Dictionary<int, Http2PendingRequest>();
         private readonly Dictionary<int, Task> _ActiveRequestTasks = new Dictionary<int, Task>();
-        private readonly Dictionary<int, CancellationTokenSource> _ActiveRequestTokens = new Dictionary<int, CancellationTokenSource>();
+        private readonly Dictionary<int, ActiveHttp2Request> _ActiveRequests = new Dictionary<int, ActiveHttp2Request>();
         private readonly Dictionary<int, int> _StreamReceiveWindows = new Dictionary<int, int>();
         private readonly Dictionary<int, int> _StreamSendWindows = new Dictionary<int, int>();
         private readonly Dictionary<int, int> _PendingStreamReceiveWindowUpdates = new Dictionary<int, int>();
@@ -167,6 +174,13 @@ namespace WatsonWebserver.Http2
         private int _PendingConnectionReceiveWindowUpdate = 0;
         private CancellationTokenSource _ReadTimeoutTokenSource = null;
         private readonly HpackDecoderContext _HpackDecoderContext;
+
+        private sealed class ActiveHttp2Request
+        {
+            public HttpContextBase Context { get; set; } = null;
+
+            public CancellationTokenSource TokenSource { get; set; } = null;
+        }
 
         private async Task HandleFrameAsync(Http2ConnectionWriter writer, Http2RawFrame frame, CancellationToken token)
         {
@@ -392,7 +406,7 @@ namespace WatsonWebserver.Http2
                 context = new Http2Context(_Settings, request, response, BuildConnectionMetadata, BuildStreamMetadata);
                 requestTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
                 context.TokenSource = requestTokenSource;
-                RegisterActiveRequestToken(streamIdentifier, requestTokenSource);
+                RegisterActiveRequest(streamIdentifier, context, requestTokenSource);
                 await _ProcessContext(context, requestTokenSource.Token).ConfigureAwait(false);
             }
             catch (Http2ProtocolException ex)
@@ -403,9 +417,23 @@ namespace WatsonWebserver.Http2
             {
                 await SendGoAwayAsync(writer, streamIdentifier, Http2ErrorCode.ProtocolError, ex.Message, token).ConfigureAwait(false);
             }
+            catch (IOException)
+            {
+                if (context != null)
+                {
+                    _MarkRequestTerminated(context, true);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                if (context != null)
+                {
+                    _MarkRequestTerminated(context, true);
+                }
+            }
             finally
             {
-                RemoveActiveRequestToken(streamIdentifier);
+                RemoveActiveRequest(streamIdentifier);
 
                 if (stateMachine.State == Http2StreamState.Closed)
                 {
@@ -1148,42 +1176,79 @@ namespace WatsonWebserver.Http2
             }
         }
 
-        private void RegisterActiveRequestToken(int streamIdentifier, CancellationTokenSource requestTokenSource)
+        private void RegisterActiveRequest(int streamIdentifier, HttpContextBase context, CancellationTokenSource requestTokenSource)
         {
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (requestTokenSource == null) throw new ArgumentNullException(nameof(requestTokenSource));
+
+            ActiveHttp2Request activeRequest = new ActiveHttp2Request();
+            activeRequest.Context = context;
+            activeRequest.TokenSource = requestTokenSource;
 
             lock (_SessionLock)
             {
-                _ActiveRequestTokens[streamIdentifier] = requestTokenSource;
+                _ActiveRequests[streamIdentifier] = activeRequest;
             }
         }
 
-        private void RemoveActiveRequestToken(int streamIdentifier)
+        private void RemoveActiveRequest(int streamIdentifier)
         {
             lock (_SessionLock)
             {
-                if (_ActiveRequestTokens.ContainsKey(streamIdentifier))
+                if (_ActiveRequests.ContainsKey(streamIdentifier))
                 {
-                    _ActiveRequestTokens.Remove(streamIdentifier);
+                    _ActiveRequests.Remove(streamIdentifier);
                 }
             }
         }
 
         private void CancelActiveRequest(int streamIdentifier)
         {
-            CancellationTokenSource requestTokenSource = null;
+            ActiveHttp2Request activeRequest = null;
 
             lock (_SessionLock)
             {
-                if (_ActiveRequestTokens.TryGetValue(streamIdentifier, out requestTokenSource))
+                if (_ActiveRequests.TryGetValue(streamIdentifier, out activeRequest))
                 {
-                    _ActiveRequestTokens.Remove(streamIdentifier);
+                    _ActiveRequests.Remove(streamIdentifier);
                 }
             }
 
-            if (requestTokenSource != null && !requestTokenSource.IsCancellationRequested)
+            MarkAndCancelActiveRequest(activeRequest, true);
+        }
+
+        private void CancelActiveRequests(bool requestorDisconnected)
+        {
+            List<ActiveHttp2Request> activeRequests = new List<ActiveHttp2Request>();
+
+            lock (_SessionLock)
             {
-                requestTokenSource.Cancel();
+                foreach (KeyValuePair<int, ActiveHttp2Request> activeRequest in _ActiveRequests)
+                {
+                    activeRequests.Add(activeRequest.Value);
+                }
+
+                _ActiveRequests.Clear();
+            }
+
+            for (int i = 0; i < activeRequests.Count; i++)
+            {
+                MarkAndCancelActiveRequest(activeRequests[i], requestorDisconnected);
+            }
+        }
+
+        private void MarkAndCancelActiveRequest(ActiveHttp2Request activeRequest, bool requestorDisconnected)
+        {
+            if (activeRequest == null) return;
+
+            if (activeRequest.Context != null)
+            {
+                _MarkRequestTerminated(activeRequest.Context, requestorDisconnected);
+            }
+
+            if (activeRequest.TokenSource != null && !activeRequest.TokenSource.IsCancellationRequested)
+            {
+                activeRequest.TokenSource.Cancel();
             }
         }
 
@@ -1275,4 +1340,3 @@ namespace WatsonWebserver.Http2
         }
     }
 }
-

--- a/src/WatsonWebserver/Http3/Http3ConnectionSession.cs
+++ b/src/WatsonWebserver/Http3/Http3ConnectionSession.cs
@@ -28,21 +28,25 @@ namespace WatsonWebserver.Http3
         /// <param name="events">Server events.</param>
         /// <param name="connection">QUIC connection.</param>
         /// <param name="processContext">Shared request processor.</param>
+        /// <param name="markRequestTerminated">Request termination callback.</param>
         public Http3ConnectionSession(
             WebserverSettings settings,
             WebserverEvents events,
             QuicConnection connection,
-            Func<HttpContextBase, CancellationToken, Task> processContext)
+            Func<HttpContextBase, CancellationToken, Task> processContext,
+            Action<HttpContextBase, bool> markRequestTerminated)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
             if (events == null) throw new ArgumentNullException(nameof(events));
             if (connection == null) throw new ArgumentNullException(nameof(connection));
             if (processContext == null) throw new ArgumentNullException(nameof(processContext));
+            if (markRequestTerminated == null) throw new ArgumentNullException(nameof(markRequestTerminated));
 
             _Settings = settings;
             _Events = events;
             _Connection = connection;
             _ProcessContext = processContext;
+            _MarkRequestTerminated = markRequestTerminated;
             _SourceIpAddress = connection.RemoteEndPoint.Address.ToString();
             _DestinationIpAddress = connection.LocalEndPoint.Address.ToString();
         }
@@ -51,10 +55,12 @@ namespace WatsonWebserver.Http3
         private readonly WebserverEvents _Events;
         private readonly QuicConnection _Connection;
         private readonly Func<HttpContextBase, CancellationToken, Task> _ProcessContext;
+        private readonly Action<HttpContextBase, bool> _MarkRequestTerminated;
         private readonly string _SourceIpAddress;
         private readonly string _DestinationIpAddress;
         private readonly object _Lock = new object();
         private readonly List<Task> _ActiveStreamTasks = new List<Task>();
+        private readonly Dictionary<long, ActiveHttp3Request> _ActiveRequests = new Dictionary<long, ActiveHttp3Request>();
         private readonly SemaphoreSlim _ControlStreamWriteLock = new SemaphoreSlim(1, 1);
         private QuicStream _OutboundControlStream = null;
         private QuicStream _OutboundQpackEncoderStream = null;
@@ -68,6 +74,13 @@ namespace WatsonWebserver.Http3
         private bool _ConnectionClosing = false;
         private long _LastAcceptedBidirectionalStreamId = 0;
         private CancellationTokenSource _AcceptTimeoutTokenSource = null;
+
+        private sealed class ActiveHttp3Request
+        {
+            public HttpContextBase Context { get; set; } = null;
+
+            public CancellationTokenSource TokenSource { get; set; } = null;
+        }
 
         /// <summary>
         /// Run the session.
@@ -137,6 +150,7 @@ namespace WatsonWebserver.Http3
             }
             catch (QuicException)
             {
+                CancelActiveRequests(true);
             }
             finally
             {
@@ -260,7 +274,7 @@ namespace WatsonWebserver.Http3
 
             try
             {
-                Http3MessageBody message = await Http3MessageSerializer.ReadMessageAsync(stream, CancellationToken.None).ConfigureAwait(false);
+                Http3MessageBody message = await Http3MessageSerializer.ReadMessageAsync(stream, token).ConfigureAwait(false);
                 if (TryGetDebugLogPath(out string debugLogPath))
                 {
                     DebugLog(debugLogPath, "request-header-block=" + Convert.ToHexString(message.Headers.HeaderBlock));
@@ -269,9 +283,20 @@ namespace WatsonWebserver.Http3
                 Http3Request request = BuildRequest(message);
                 Http3Response response = new Http3Response(request, _Settings, stream);
                 context = new Http3Context(_Settings, request, response, BuildConnectionMetadata, BuildStreamMetadata);
-                requestTokenSource = new CancellationTokenSource();
+                requestTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
                 context.TokenSource = requestTokenSource;
-                await _ProcessContext(context, requestTokenSource.Token).ConfigureAwait(false);
+                RegisterActiveRequest(stream.Id, context, requestTokenSource);
+
+                Task disconnectMonitor = MonitorHttp3DisconnectAsync(stream, context, requestTokenSource.Token);
+                try
+                {
+                    await _ProcessContext(context, requestTokenSource.Token).ConfigureAwait(false);
+                }
+                finally
+                {
+                    requestTokenSource.Cancel();
+                    await disconnectMonitor.ConfigureAwait(false);
+                }
             }
             catch (Http3ProtocolException e)
             {
@@ -285,11 +310,24 @@ namespace WatsonWebserver.Http3
             catch (OperationCanceledException)
             {
             }
+            catch (QuicException)
+            {
+                if (context != null)
+                {
+                    _MarkRequestTerminated(context, true);
+                }
+            }
             catch (IOException)
             {
+                if (context != null)
+                {
+                    _MarkRequestTerminated(context, true);
+                }
             }
             finally
             {
+                RemoveActiveRequest(stream.Id);
+
                 if (context != null)
                 {
                     context.Dispose();
@@ -573,6 +611,95 @@ namespace WatsonWebserver.Http3
             lock (_Lock)
             {
                 _ActiveStreamTasks.Add(streamTask);
+            }
+        }
+
+        private void RegisterActiveRequest(long streamIdentifier, HttpContextBase context, CancellationTokenSource tokenSource)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (tokenSource == null) throw new ArgumentNullException(nameof(tokenSource));
+
+            ActiveHttp3Request activeRequest = new ActiveHttp3Request();
+            activeRequest.Context = context;
+            activeRequest.TokenSource = tokenSource;
+
+            lock (_Lock)
+            {
+                _ActiveRequests[streamIdentifier] = activeRequest;
+            }
+        }
+
+        private void RemoveActiveRequest(long streamIdentifier)
+        {
+            lock (_Lock)
+            {
+                if (_ActiveRequests.ContainsKey(streamIdentifier))
+                {
+                    _ActiveRequests.Remove(streamIdentifier);
+                }
+            }
+        }
+
+        private void CancelActiveRequests(bool requestorDisconnected)
+        {
+            List<ActiveHttp3Request> activeRequests = new List<ActiveHttp3Request>();
+
+            lock (_Lock)
+            {
+                foreach (KeyValuePair<long, ActiveHttp3Request> activeRequest in _ActiveRequests)
+                {
+                    activeRequests.Add(activeRequest.Value);
+                }
+
+                _ActiveRequests.Clear();
+            }
+
+            for (int i = 0; i < activeRequests.Count; i++)
+            {
+                MarkAndCancelActiveRequest(activeRequests[i], requestorDisconnected);
+            }
+        }
+
+        private void MarkAndCancelActiveRequest(ActiveHttp3Request activeRequest, bool requestorDisconnected)
+        {
+            if (activeRequest == null) return;
+
+            if (activeRequest.Context != null)
+            {
+                _MarkRequestTerminated(activeRequest.Context, requestorDisconnected);
+            }
+
+            if (activeRequest.TokenSource != null && !activeRequest.TokenSource.IsCancellationRequested)
+            {
+                activeRequest.TokenSource.Cancel();
+            }
+        }
+
+        private async Task MonitorHttp3DisconnectAsync(QuicStream stream, HttpContextBase context, CancellationToken token)
+        {
+            if (stream == null || context == null) return;
+
+            Task cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, token);
+            Task completedTask = null;
+
+            try
+            {
+                completedTask = await Task.WhenAny(stream.WritesClosed, cancellationTask).ConfigureAwait(false);
+                if (completedTask == stream.WritesClosed && !context.Response.ResponseStarted)
+                {
+                    try
+                    {
+                        await stream.WritesClosed.ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                    }
+
+                    _MarkRequestTerminated(context, true);
+                }
+            }
+            catch (OperationCanceledException)
+            {
             }
         }
 

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -3,9 +3,9 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
-		<Version>7.0.14</Version>
+		<Version>7.0.15</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with unified 7.x protocol architecture targeting .NET Standard 2.1, .NET 8, and .NET 10.</Description>
-		<PackageReleaseNotes>Fixed HTTP/1.1 disconnect detection so client disconnects raise abort and disconnect events correctly, avoid false response-sent telemetry, and added regression coverage for large-response disconnect handling.</PackageReleaseNotes>
+		<PackageReleaseNotes>Fixed active request cancellation for caller disconnects so HTTP/1.1 socket disconnects, HTTP/2 RST_STREAM frames, and HTTP/3 response-side stream closures cancel the per-request token and raise abort/disconnect events while handlers are still running.</PackageReleaseNotes>
 
 		<Authors>Joel Christner</Authors>
 		<Company>Joel Christner</Company>

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -622,7 +622,8 @@
                     Settings,
                     Events,
                     quicConnection,
-                    async (httpContext, cancellationToken) => await ProcessHttpContextAsync(httpContext, _Header, cancellationToken).ConfigureAwait(false));
+                    async (httpContext, cancellationToken) => await ProcessHttpContextAsync(httpContext, _Header, cancellationToken).ConfigureAwait(false),
+                    MarkRequestTerminated);
                 await session.RunAsync(token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -658,6 +659,7 @@
 
             Stream stream = tcpClient.GetStream();
             ClientStreamContext context = new ClientStreamContext();
+            context.Socket = tcpClient.Client;
 
             if (!Settings.Ssl.Enable)
             {
@@ -779,6 +781,7 @@
                         Events,
                         clientStream,
                         async (httpContext, cancellationToken) => await ProcessHttpContextAsync(httpContext, _Header, cancellationToken).ConfigureAwait(false),
+                        MarkRequestTerminated,
                         sourceEndpoint,
                         destinationEndpoint,
                         Settings.Ssl.Enable);
@@ -836,7 +839,17 @@
                                 ctx = RentHttpContext(clientStream, requestMetadata);
                                 ctx.TokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
 
-                                await ProcessHttpContextAsync(ctx, _Header, ctx.Token).ConfigureAwait(false);
+                                Task disconnectMonitor = MonitorHttp1DisconnectAsync(streamContext, ctx, ctx.Token);
+                                try
+                                {
+                                    await ProcessHttpContextAsync(ctx, _Header, ctx.Token).ConfigureAwait(false);
+                                }
+                                finally
+                                {
+                                    ctx.CancelRequestToken();
+                                    await disconnectMonitor.ConfigureAwait(false);
+                                }
+
                                 keepAlive = ShouldKeepConnectionOpen(ctx);
                                 firstRequest = false;
                             }
@@ -891,6 +904,74 @@
                 catch (Exception)
                 {
                 }
+            }
+        }
+
+        private async Task MonitorHttp1DisconnectAsync(ClientStreamContext streamContext, HttpContextBase ctx, CancellationToken token)
+        {
+            if (streamContext == null || streamContext.Socket == null || ctx == null) return;
+
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    if (IsRequestBodyComplete(ctx) && IsSocketDisconnected(streamContext.Socket))
+                    {
+                        if (!ctx.Response.ResponseCompleted)
+                        {
+                            MarkRequestTerminated(ctx, true);
+                        }
+
+                        return;
+                    }
+
+                    await Task.Delay(50, token).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+                if (!ctx.Response.ResponseCompleted)
+                {
+                    MarkRequestTerminated(ctx, true);
+                }
+            }
+            catch (SocketException)
+            {
+                if (!ctx.Response.ResponseCompleted)
+                {
+                    MarkRequestTerminated(ctx, true);
+                }
+            }
+        }
+
+        private static bool IsRequestBodyComplete(HttpContextBase ctx)
+        {
+            if (ctx == null) return false;
+
+            HttpRequest request = ctx.Request as HttpRequest;
+            if (request == null) return true;
+
+            return request.IsRequestBodyComplete;
+        }
+
+        private static bool IsSocketDisconnected(Socket socket)
+        {
+            if (socket == null) return false;
+
+            try
+            {
+                return socket.Poll(0, SelectMode.SelectRead) && socket.Available == 0;
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
+            catch (SocketException)
+            {
+                return true;
             }
         }
 


### PR DESCRIPTION
## Summary

- Propagates caller disconnects to active request tokens while handlers are still running.
- Adds HTTP/1.1 active socket disconnect monitoring after request body completion.
- Tracks active HTTP/2 and HTTP/3 request contexts so stream resets/transport failures mark requests terminated and emit RequestAborted / RequestorDisconnected.
- Bumps Watson to 7.0.15 and updates changelog/package release notes.

## Validation

- dotnet build src\WatsonWebserver.sln -c Debug
- focused new xUnit tests
- dotnet run --project src\Test.Automated\Test.Automated.csproj -c Debug -f net10.0
- dotnet test src\Test.XUnit\Test.XUnit.csproj -c Debug -f net10.0
- dotnet build src\WatsonWebserver.sln -c Release

Release artifacts generated locally:

- src\WatsonWebserver\bin\Release\Watson.7.0.15.nupkg
- src\WatsonWebserver\bin\Release\Watson.7.0.15.snupkg